### PR TITLE
Fix migrations

### DIFF
--- a/migrations/0001_initial.py
+++ b/migrations/0001_initial.py
@@ -9,7 +9,7 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('repository', '0036_alter_preprintversion_title'),
+        ('repository', '0035_alter_preprintaccess_options'),
     ]
 
     operations = [

--- a/migrations/0002_auto_20231023_1625.py
+++ b/migrations/0002_auto_20231023_1625.py
@@ -7,7 +7,7 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('repository', '0036_alter_preprintversion_title'),
+        ('repository', '0035_alter_preprintaccess_options'),
         ('merritt', '0001_initial'),
     ]
 


### PR DESCRIPTION
The merritt plugin migration was made on stg after a repository migration that is non-canonical  was applied and therefore depended on it.  It doesn't actually depend on that migration and I need to get that migration out of the way to update to 1.5.1.

- Bump the dependency back 1 migration in the repository module.