### PR TITLE
Updates due to Merritt side changes

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -161,6 +161,7 @@ class MerrittForPreprint:
             'date':(None, str(self.preprint.date_published)),
             'creator': (None, self.getCreators()),
             'responseForm': (None, 'xml'),
+            'notificationFormat': (None, 'json'),
             'profile': (None, self.collection),
             'localIdentifier': (None, self.preprint.id),
         }

--- a/views.py
+++ b/views.py
@@ -55,7 +55,7 @@ def process_callback(data):
     job = MerrittJobStatus(job_id = job_id, callback_date = timezone.now(), callback_response = json.dumps(data), preprint_id=preprint_id)
     qitem = MerrittQueue.objects.get(preprint_id = preprint_id)
     ritem = PreprintMerrittRequests.objects.filter(preprint_id = preprint_id, status = PreprintMerrittRequests.SubmissionStatus.SENT).order_by('-request_date').first()
-    if "COMPLETED" in status:
+    if "COMPLETED" in status or "CONSUMED" in status:
         job.status = MerrittJobStatus.JobStatus.COMPLETED
         qitem.status = MerrittQueue.ItemStatus.COMPLETED
         ritem.status = PreprintMerrittRequests.SubmissionStatus.DONE


### PR DESCRIPTION
First change relates to callback format. It used to be json by default now we need to ask for it in request. Merritt is currently sending different status on completion than before. Merritt team informed that status will be back to the older string after some time.  I updated the callback to accept both. 